### PR TITLE
Fixtests

### DIFF
--- a/src/main/java/io/frictionlessdata/datapackage/Resource.java
+++ b/src/main/java/io/frictionlessdata/datapackage/Resource.java
@@ -250,7 +250,7 @@ public class Resource {
                 
                 //FIXME: Multipart data.
             }else{
-                throw new DataPackageException("Unsupported data type for Resource path. Should be String or List but was " + this.getPath().getClass().getTypeName());
+                throw new DataPackageException("Unsupported data type for Resource path. Should be String or URL but was " + this.getPath().getClass().getTypeName());
             }
             
         }else if (this.getData() != null){

--- a/src/main/java/io/frictionlessdata/datapackage/Resource.java
+++ b/src/main/java/io/frictionlessdata/datapackage/Resource.java
@@ -250,7 +250,7 @@ public class Resource {
                 
                 //FIXME: Multipart data.
             }else{
-                throw new DataPackageException("Unsupported data type for Resource path. Should be String or URL but was " + this.getPath().getClass().getTypeName());
+                throw new DataPackageException("Unsupported data type for Resource path. Should be File or URL but was " + this.getPath().getClass().getTypeName());
             }
             
         }else if (this.getData() != null){

--- a/src/test/java/io/frictionlessdata/datapackage/ResourceTest.java
+++ b/src/test/java/io/frictionlessdata/datapackage/ResourceTest.java
@@ -3,6 +3,7 @@ package io.frictionlessdata.datapackage;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -159,12 +160,9 @@ public class ResourceTest {
         String filePath = ResourceTest.class.getResource("/fixtures/data/population.csv").getPath();
         File file = new File(filePath);
 
-        // Get path of schema file used when creating the test package.
-        String schemaFilePath = PackageTest.class.getResource("/fixtures/schema/population_schema.json").getPath();
-
         // Get string content version of the schema file.
-        String schemaJsonString = new String(Files.readAllBytes(Paths.get(schemaFilePath)));
-        
+        String schemaJsonString = getFileContents("/fixtures/schema/population_schema.json");
+
         // Get JSON Object
         JSONObject schemaJson = new JSONObject(schemaJsonString);
         Resource resource = new Resource("population", file, schemaJson);
@@ -291,6 +289,19 @@ public class ResourceTest {
         Assert.assertEquals("city", resource.getHeaders()[0]);
         Assert.assertEquals("year", resource.getHeaders()[1]);
         Assert.assertEquals("population", resource.getHeaders()[2]);
+    }
+
+
+    private static String getFileContents(String fileName) {
+        try {
+            // Create file-URL of source file:
+            URL sourceFileUrl = ResourceTest.class.getResource(fileName);
+            // Get path of URL
+            Path path = Paths.get(sourceFileUrl.toURI());
+            return new String(Files.readAllBytes(path));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
     }
     
     private List<String[]> getExpectedPopulationData(){


### PR DESCRIPTION
# Overview

Compiling the datapackage-java JAR under Windows gives me some of the same exceptions mentioned in [my pull request for tableschema-java](https://github.com/frictionlessdata/tableschema-java/pull/28). 

This is due to the incorrect construction of the path in question; a similar question and explanation can be found here: https://bugs.openjdk.java.net/browse/JDK-8197918?focusedCommentId=14156698&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14156698

The underlying problem doesn't manifest on Unix-like systems, but due to Windows peculiar file paths, it triggers an exception.

After applying the proposed solution, the tests all pass in my environment.

---

Please preserve this line to notify @georgeslabreche (maintainer of this repository)
